### PR TITLE
Fix missing argon2 and keyring dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ rich==13.4.2
 PyMuPDF
 pandas==2.2.3
 filelock==3.16.1
+argon2-cffi
+keyring
 


### PR DESCRIPTION
## Summary
- add argon2-cffi to requirements
- add keyring to requirements

## Testing
- `pip install -r requirements.txt`
- `python main.py --help` *(fails: Parameter.make_metavar() missing 1 required positional argument: 'ctx')*

------
https://chatgpt.com/codex/tasks/task_e_68432350e38c832fa6ac3edf23dd95fa